### PR TITLE
Remove redundant "featurep" check

### DIFF
--- a/pydoc.el
+++ b/pydoc.el
@@ -28,8 +28,7 @@
 
 ;;; Code:
 ;; we use org-mode for python fontification
-(unless (featurep 'org)
-  (require 'org))
+(require 'org)
 
 (defvar *pydoc-current* nil
  "Stores current pydoc command.")


### PR DESCRIPTION
(In connection with https://github.com/milkypostman/melpa/pull/2586)

`local-set-key` is often a sign that a major or minor mode is needed, even if it's not exposed for the end-user to use directly. So you might also consider making a `pydoc-mode` to wrap up all the keybindings in the `pydoc` command, so that they become accessible to users for customisation.
