### PR TITLE
Fix #20 using importlib_metadata

### DIFF
--- a/pydoc.el
+++ b/pydoc.el
@@ -475,6 +475,14 @@ Adapted from `help-make-xrefs'."
 
 (defun pydoc-user-modules ()
   "Return a list of strings for user-installed modules."
+  (mapcar 'symbol-name
+          (read
+           (shell-command-to-string
+            "python -c \"import pip; mods = sorted([i.key for i in pip.get_installed_distributions()]); print('({})'.format(' '.join(['\"{}\"'.format(x) for x in mods])))  \""))))
+
+
+(defun pydoc-user-modules ()
+  "Return a list of strings for user-installed modules."
   (if (executable-find "pip")
       (if (< (car (pydoc-pip-version)) 10)
 	  (mapcar


### PR DESCRIPTION
Since Python 3.8, pydoc-user-modules has been broken due to the pip developers removing pip.get_installed_distributions.  This pull request fixes this by switching to importlib_metadata (a backport of importlib.metadata).  This means that the code will also work with Python 2 so long as the importlib_metadata package is installed.