### PR TITLE
Fix #20 using importlib.metadata and importlib_metadata

### DIFF
--- a/pydoc.el
+++ b/pydoc.el
@@ -481,7 +481,7 @@ Adapted from `help-make-xrefs'."
     (shell-command-to-string
      ;; Use either importlib_metadata (a backport of importlib.metadata) or
      ;; importlib.metadata itself if it is available.
-     (concat python-shell-interpreter " -c \"try: import importlib_metadata;implib_meta = importlib_metadata\nexcept: pass\ntry: import importlib.metadata;implib_meta = importlib.metadata\nexcept: implib_meta = None\nmods = sorted(map(lambda x: x.metadata['name'], implib_meta.distributions())); print('({})'.format(' '.join(['\"{}\"'.format(x) for x in mods])))  \"")))))
+     (concat python-shell-interpreter " -c \"implib_meta = None\ntry: import importlib_metadata;implib_meta = importlib_metadata\nexcept: pass\ntry: import importlib.metadata;implib_meta = importlib.metadata\nexcept: pass\nmods = sorted(map(lambda x: x.metadata['name'], implib_meta.distributions())); print('({})'.format(' '.join(['\"{}\"'.format(x) for x in mods])))  \"")))))
 
 
 (defun pydoc-pkg-modules ()

--- a/pydoc.el
+++ b/pydoc.el
@@ -481,7 +481,10 @@ Adapted from `help-make-xrefs'."
     (shell-command-to-string
      ;; Use either importlib_metadata (a backport of importlib.metadata) or
      ;; importlib.metadata itself if it is available.
-     (concat python-shell-interpreter " -c \"implib_meta = None\ntry: import importlib_metadata;implib_meta = importlib_metadata\nexcept: pass\ntry: import importlib.metadata;implib_meta = importlib.metadata\nexcept: pass\nmods = sorted(map(lambda x: x.metadata['name'], implib_meta.distributions())); print('({})'.format(' '.join(['\"{}\"'.format(x) for x in mods])))  \"")))))
+     (concat python-shell-interpreter " -c \"implib_meta_backport = None\nimplib_meta_python = None\ntry: import importlib_metadata;implib_meta_backport = importlib_metadata\nexcept: pass\ntry: import importlib.metadata;implib_meta_python = importlib.metadata\nexcept: pass\nimplib_meta = implib_meta_python or implib_meta_backport\nmods = sorted(map(lambda x: x.metadata['name'], implib_meta.distributions())); print('({})'.format(' '.join(['\"{}\"'.format(x) for x in mods])))  \"")
+     ;; For older versions of Python.
+     ;; (concat python-shell-interpreter " -c \"import pip; mods = sorted([i.key for i in pip.get_installed_distributions()]); print('({})'.format(' '.join(['\"{}\"'.format(x) for x in mods])))  \"")
+     ))))
 
 
 (defun pydoc-pkg-modules ()


### PR DESCRIPTION
Since Python 3.8, pydoc-user-modules has been broken due to the pip developers removing pip.get_installed_distributions. This pull request fixes this by using importlib.metadata (new in Python 3.8) or importlib_metadata (a backport of importlib.metadata) when importlib.metadata is not available (Python 2.x and older versions of Python 3). This means that the code will also work with Python 2 and Python 3.4-3.7 so long as the importlib_metadata package is installed.