### PR TITLE
Implement 'pydoc-at-point-no-jedi' to replace 'pydoc-at-point'.

### DIFF
--- a/pydoc.el
+++ b/pydoc.el
@@ -764,6 +764,25 @@ This is cached for speed. Use a prefix arg to refresh it."
     (call-process-shell-command (concat pydoc-command " " name)
 				nil standard-output)))
 
+;;* The pydoc functions
+;;;###autoload
+(defun pydoc-at-point-no-jedi (&optional prompt)
+  "Try to get help for thing at point without python-jedi.
+With non-nil PROMPT or without a thing, prompt for the function or module."
+  (interactive "P")
+  (let ((name-of-symbol-at-point (if (symbol-at-point)
+				     (symbol-name (symbol-at-point))
+				   "")))
+    (if (or prompt
+	    (not (symbol-at-point)))
+	(pydoc (completing-read
+		"Name of function or module: "
+		(pydoc-all-modules current-prefix-arg)
+		nil nil
+		name-of-symbol-at-point))
+      (pydoc name-of-symbol-at-point))) )
+
+
 ;;;###autoload
 (defun pydoc-at-point ()
   "Try to get help for thing at point.


### PR DESCRIPTION
This will partially fix Issue [720198043](https://github.com/statmobile/pydoc/issues/24#issue-720198043) by completely abolish jedi.
Initially, I wanted to fix `pydoc-at-point` but I had no idea how to use jedi, so I decide to ignore it.
Not having used Python extensively to comprehend jedi's features, but I think this command can be an emergency fix for `pydoc-at-point` and we won't have to go around and adapt to jedi's non-backward-compatible breakages in the future.
Locally I have `pydoc-at-point-no-jedi` named `pydoc-at-point` to replace it completely.