### PR TITLE
add cl prefix to loop function

### DIFF
--- a/pydoc.el
+++ b/pydoc.el
@@ -866,7 +866,7 @@ Attempts to find an open port, and to reuse the process."
   (unless *pydoc-browser-process*
     ;; find an open port
     (if (executable-find "lsof")
-	(loop for port from 1025
+	(cl-loop for port from 1025
 	      if (string= "" (shell-command-to-string (format "lsof -i :%s" port)))
 	      return (setq *pydoc-browser-port* (number-to-string port)))
       ;; Windows may not have an lsof command.


### PR DESCRIPTION
Functions from cl-lib should use the cl prefix to prevent collision with the old cl library, particularly in older versions of emacs. For example, in my case, I think one of my other packages was using the old version, and when it loaded pydoc, it tried to use the old cl version and I got an error. Flycheck also gives me errors there without the prefix.