### PR TITLE
Avoid AOT compilation warning on undefined pydoc-treesit-at-point

### DIFF
--- a/pydoc.el
+++ b/pydoc.el
@@ -864,6 +864,8 @@ FILE
 				  nil standard-output)
       (delete-file tfile))))
 
+;; Avoid missing function warning when AOT compiling module
+(autoload 'pydoc-treesit-at-point "pydoc-treesit")
 
 ;;;###autoload
 (defun pydoc-at-point ()


### PR DESCRIPTION
I pulled the latest version of this package via straight.el today, and got an AOT compiler warning:

```
⛔ Warning (native-compiler): [...]/pydoc.el:875:26: Warning: the function ‘pydoc-treesit-at-point’ is not known to be defined.
```

IIUC the AOT compiler runs without benefit of automatic autoload defs, so it doesn't know this function exists. (Everything still works fine, aside from the warning.)

This PR avoids the warning by adding an explicit autoload clause. This seems a bit clunky, but was the best option I could come up without deeper refactoring:

* I originally tried adding a `(eval-when-compile (require 'pydoc-treesit))` but that leads to a cyclic expansion as `pydoc-treesit` already requires `pydoc`.
* I also experimented with wrapping `pydoc-at-point` with an advice in `pydoc-treesit.el`, instead of referring to it from `pydoc.el`. However, then treesitter support only works if you change your `init.el` to require `pydoc-treesit` directly instead of `pydoc`. To avoid that would need more changes to add something like `(eval-after-load 'pydoc '(require 'pydoc-treesit))`, which felt like a can of worms...

I am not an emacs wizard by any means, so very possible there's a cleaner solution than this one that I have not considered. :smile: 

Thanks @statmobile for maintaining this useful emacs package, and to @okomestudio for adding the treesitter support in #34. :heart: 