### PR TITLE
Suppress warnings for running org-element function in non-org buffer

### DIFF
--- a/pydoc.el
+++ b/pydoc.el
@@ -582,8 +582,9 @@ These are lines marked by `pydoc-example-code-leader-re'."
   (when (re-search-forward pydoc-example-code-leader-re limit t)
     (set-text-properties (match-beginning 1) (match-end 1)
                          '(font-lock-face pydoc-example-leader-face))
-    (org-src-font-lock-fontify-block
-     "python" (match-beginning 2) (match-end 2))
+		(let ((warning-minimum-log-level :error))
+      (org-src-font-lock-fontify-block
+       "python" (match-beginning 2) (match-end 2)))
     t))
 
 

--- a/pydoc.el
+++ b/pydoc.el
@@ -582,7 +582,7 @@ These are lines marked by `pydoc-example-code-leader-re'."
   (when (re-search-forward pydoc-example-code-leader-re limit t)
     (set-text-properties (match-beginning 1) (match-end 1)
                          '(font-lock-face pydoc-example-leader-face))
-		(let ((warning-minimum-log-level :error))
+		(let ((major-mode 'org-mode))
       (org-src-font-lock-fontify-block
        "python" (match-beginning 2) (match-end 2)))
     t))


### PR DESCRIPTION
This PR provides a fix for #36.

Adjusting the warning log threshold suppresses the warnings generated when the org-element function is run within a non-Org buffer. This seems necessary for pydoc, as the pydoc mode uses Org for rendering inline code. 